### PR TITLE
Quick doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The `make cmap` is necessary for documents containing Chinese characters.
 
 Just type
 
-	python main.pdf <pdf>
+	python main.py <pdf>
 
 For example, you can use our example PDF file:
 
-	python main.pdf examples/neihu.pdf
+	python main.py examples/neihu.pdf
 


### PR DESCRIPTION
Was trying out the project and noticed the documentation had "pdf" in a spot where it should be "py"
